### PR TITLE
Fix code formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Notes
 -----
 * All methods return a Float object except for `mode`, which will return a Numeric object from the collection. `mode` will always return nil for empty collections.
 * All methods return nil when the collection is empty, except for `number`, which returns 0.0. This is a different behavior than [ActiveSupport's Enumerable monkey patch of sum](http://apidock.com/rails/Enumerable/sum), which by deafult returns the Fixnum 0 for empty collections. You can change this behavior by specifying the default value returned for empty collections all at once:
-  ```ruby
+```ruby
 require 'descriptive_statistics'
 [].mean
 # => nil
@@ -246,9 +246,9 @@ DescriptiveStatistics.empty_collection_default_value = 0.0
 # => 0.0
 [].sum
 # => 0.0
-  ```
-  or one at a time:
-  ```ruby
+```
+or one at a time:
+```ruby
 require 'descriptive_statistics'
 [].mean
 # => nil
@@ -266,7 +266,7 @@ DescriptiveStatistics.mean_empty_collection_default_value = 0.0
 # => 0.0
 [].sum
 # => 0.0
-  ```
+```
 
 * The scope of this gem covers [Descriptive Statistics](http://en.wikipedia.org/wiki/Descriptive_statistics) and not Inferential Statistics. From wikipedia:
 


### PR DESCRIPTION
The code in the notes section was not formatting correctly due to extra spaces.